### PR TITLE
Avoid horizontal scrolling on mobile

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -8,6 +8,11 @@ body {
   margin-bottom: 120px;
 }
 
+.main-container {
+  padding: 0;
+  overflow: hidden;
+}
+
 /* My Custom Written Styles */
 
 .specifictd {

--- a/views/index.html
+++ b/views/index.html
@@ -33,7 +33,7 @@
     </script>
   </head>
   <body ng-app="myApp" ng-controller="myCtrl">
-    <div style="container">
+    <div class="main-container container">
       <div class="row">
         <div class="col-md-10 col-md-offset-1">
           <table class="table table-sm">


### PR DESCRIPTION
This corrects a typo in the markup that was causing horizontal scrolling on small screens. It also zeroes out the extra padding the fix would have created so it's flush with the edges again.